### PR TITLE
Access schema through compiled classes.

### DIFF
--- a/src/main/scala/com/cloudera/sparkavro/SparkSpecificAvroWriter.scala
+++ b/src/main/scala/com/cloudera/sparkavro/SparkSpecificAvroWriter.scala
@@ -18,18 +18,14 @@
 
 package com.cloudera.sparkavro
 
-import org.apache.avro.Schema.Parser
 import org.apache.avro.mapred.AvroKey
 import org.apache.avro.mapreduce.{AvroJob, AvroKeyOutputFormat}
-
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.NullWritable
 import org.apache.hadoop.mapreduce.Job
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
-
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.SparkContext._
-import org.apache.spark.SparkConf
 
 object SparkSpecificAvroWriter {
   def main(args: Array[String]) {
@@ -47,7 +43,7 @@ object SparkSpecificAvroWriter {
 
     val conf = new Job()
     FileOutputFormat.setOutputPath(conf, new Path(outPath))
-    val schema = new Parser().parse(getClass.getClassLoader.getResourceAsStream("user.avsc"))
+    val schema = User.SCHEMA$
     AvroJob.setOutputKeySchema(conf, schema)
     conf.setOutputFormatClass(classOf[AvroKeyOutputFormat[User]])
     withValues.saveAsNewAPIHadoopDataset(conf.getConfiguration)

--- a/src/main/scala/com/cloudera/sparkavro/SparkSpecificParquetWriter.scala
+++ b/src/main/scala/com/cloudera/sparkavro/SparkSpecificParquetWriter.scala
@@ -18,16 +18,11 @@
 
 package com.cloudera.sparkavro
 
-import org.apache.avro.Schema.Parser
-
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.Job
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
-
-import org.apache.spark.SparkConf
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.SparkContext._
-
 import parquet.avro.AvroParquetOutputFormat
 
 object SparkSpecificParquetWriter {
@@ -45,7 +40,7 @@ object SparkSpecificParquetWriter {
 
     val conf = new Job()
     FileOutputFormat.setOutputPath(conf, new Path(outPath))
-    val schema = new Parser().parse(getClass.getClassLoader.getResourceAsStream("user.avsc"))
+    val schema = User.SCHEMA$
     AvroParquetOutputFormat.setSchema(conf, schema)
     conf.setOutputFormatClass(classOf[AvroParquetOutputFormat])
     records.map((x) => (null, x)).saveAsNewAPIHadoopDataset(conf.getConfiguration)


### PR DESCRIPTION
If you have a compiled avro class on your class path, you can access it's schema directly without needing to parse it out of a file. I often find this to be easier.
